### PR TITLE
Fix Failed callback exception

### DIFF
--- a/aioviberbot/api/viber_requests/viber_failed_request.py
+++ b/aioviberbot/api/viber_requests/viber_failed_request.py
@@ -12,9 +12,9 @@ class ViberFailedRequest(ViberRequest):
 
     def from_dict(self, request_dict):
         super(ViberFailedRequest, self).from_dict(request_dict)
-        self._message_token = request_dict['message_token']
-        self._user_id = request_dict['user_id']
-        self._desc = request_dict['desc']
+        self._message_token = request_dict.get('message_token')
+        self._user_id = request_dict.get('user_id')
+        self._desc = request_dict.get('desc')
         return self
 
     @property


### PR DESCRIPTION
Viber API describes Failed callback data as
```
{  
   "event":"failed",
   "timestamp":1457764197627,
   "message_token":4912661846655238145,
   "user_id":"01234567890A=",
   "desc":"failure description"
}
```

but real data I receive is
```
{
  "event":"failed",
  "timestamp":1724144977404,
  "chat_hostname":"SN-CALLBACK-04_",
  "message_token":6006561542695701465,
  "user_id":"01234567890A==",
  "udid":null
}
```

`aioviberbot` throws an exception while parsing that message
```
Error handling request
Traceback (most recent call last):
  File "/usr/local/lib/python3.12/site-packages/aiohttp/web_protocol.py", line 456, in _handle_request
    resp = await request_handler(request)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/aiohttp/web_app.py", line 537, in _handle
    resp = await handler(request)
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/receiver/./receiver.py", line 158, in receive_viber_message
    viber_request = viber.parse_request(content.decode())
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/aioviberbot/api/api.py", line 60, in parse_request
    request = create_request(request_dict)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/aioviberbot/api/viber_requests/__init__.py", line 33, in create_request
    return EVENT_TYPE_TO_CLASS[request_dict['event']]().from_dict(request_dict)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/aioviberbot/api/viber_requests/viber_failed_request.py", line 17, in from_dict
    self._desc = request_dict['desc']
                 ~~~~~~~~~~~~^^^^^^^^
KeyError: 'desc'
```

I suggest to parse data with `dict.get` method